### PR TITLE
chore: remove numpy version upper bound in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 onnxruntime>=1.7.0
 opencv_python>=4.5.1.48
-numpy>=1.21.6,<2
+numpy>=2.0.0
 Pillow
 tqdm
 requests


### PR DESCRIPTION
remove numpy version upper bound, reference #21 